### PR TITLE
Added bash as explicit dependency to fix OSX issue

### DIFF
--- a/Formula/bashpile.rb
+++ b/Formula/bashpile.rb
@@ -5,12 +5,18 @@ class Bashpile < Formula
   url "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "main", tag: "0.21.4"
   head "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "development"
 
-  depends_on "gnu-sed"
-  depends_on "maven" => :build
-  depends_on "bc"
+  # foundational dependencies
   depends_on "openjdk"
+  depends_on "bash"
+  depends_on "maven" => :build
+
+  # tooling dependencies for compilation
   depends_on "shfmt"
   depends_on "shellcheck"
+
+  # tooling dependencies for generated scripts
+  depends_on "gnu-sed"
+  depends_on "bc"
   # TODO add gnu-getopt for OSX or FreeBSD only
 
   def install

--- a/bin/generate-docs
+++ b/bin/generate-docs
@@ -1,4 +1,8 @@
 #!/usr/bin/env bpr
 
+// ensure docutils is installed
+
+mkdir docs/generated || true
+mkdir docs/generated/tutorial || true
 docutils docs/enduser/index.rst docs/generated/index.html
 docutils docs/enduser/tutorial/index.rst docs/generated/tutorial/index.html

--- a/src/test/resources/debian-safe/Dockerfile
+++ b/src/test/resources/debian-safe/Dockerfile
@@ -10,17 +10,14 @@ LABEL authors="Michael Amiethyst"
 
 # Setup system and user
 RUN apt update && apt upgrade && apt-get -y install curl git build-essential procps
-RUN useradd -ms /bin/bash dockeruser
+# skip user-add for simple and safe mode
 
 # install brew
 RUN /bin/bash -c "NONINTERACTIVE=1 $(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # install Bashpile
 RUN /bin/bash -c "eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\" \
-    && brew install gcc && brew install --HEAD michael-amiethyst/bashpile/bashpile"
+    && brew install gcc && brew install --HEAD michael-amiethyst/bashpile/bashpile || \
+    cat /root/.cache/Homebrew/Logs/bashpile/01.mvn"
 
-# finish setting up user and start
-RUN chown -R dockeruser /home/linuxbrew/.linuxbrew
-USER dockeruser
-WORKDIR /home/dockeruser
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## Describe your changes
Improved ordering of bashpile.rb dependencies.

## Issue ticket number and link
Fixes Bug #25.  Debian build wouldn't work, Brew path not passed into Bashpile JVM shell

## Merge to Development - Checklist before requesting a review
- [x] I have performed a self-review of my code.  It runs with `mvn clean verify`
- [x] I have added thorough tests.

## Merge to Main - Checklist before requesting a review
- [x] I have installed this version locally
- [x] I have tested on Debian with `docker build --no-cache -t "debian-bashpile" src/test/resources/docker/debian`
- [x] I have regenerated the docutils documentation with `bin/generate-docs`