### PR TITLE
OSX getopt fix

### DIFF
--- a/Formula/bashpile.rb
+++ b/Formula/bashpile.rb
@@ -2,7 +2,7 @@ class Bashpile < Formula
   desc "The Bash Transpiler: Write in a modern language and run in a Bash5 shell!"
   homepage "https://github.com/michael-amiethyst/homebrew-bashpile"
   license "MIT"
-  url "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "main", tag: "0.21.4"
+  url "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "main", tag: "0.21.5"
   head "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "development"
 
   # foundational dependencies

--- a/Formula/bashpile.rb
+++ b/Formula/bashpile.rb
@@ -17,7 +17,7 @@ class Bashpile < Formula
   # tooling dependencies for generated scripts
   depends_on "gnu-sed"
   depends_on "bc"
-  # TODO add gnu-getopt for OSX or FreeBSD only
+  depends_on "gnu-getopt" # needed for OSX and FreeBSD, kept as generic dependency for consistency
 
   def install
     system "mvn", "clean", "verify", "-Dskip.failsafe.tests=true" # Integration tests can't find dependencies on PATH

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.bashpile</groupId>
   <artifactId>bashpile</artifactId>
-  <version>0.21.3</version>
+  <version>0.21.5</version>
   <build>
     <finalName>bashpile</finalName>
     <plugins>

--- a/docs/contributor/changelog.md
+++ b/docs/contributor/changelog.md
@@ -26,4 +26,5 @@
 * 0.21.1 - Getopt switch fix
 * 0.21.2 - If regularFileExists (-f), directoryExists (-d).  Fixed a few TODOs, Kotlin integration
 * 0.21.3 - Fix for error on brew install now that more testing was enabled
-* 0.21.4 - Pulled extra testing during install
+* 0.21.4 - Removed recently added extra testing during install
+* 0.21.5 - OSX Brew install fixes, added Bash and gnu-getopt dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bashpile</groupId>
     <artifactId>bashpile</artifactId>
-    <version>0.21.4</version>
+    <version>0.21.5</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
## Describe your changes
OSX uses the FreeBSD getopt that does not support long options

## Issue ticket number and link
Fixes Bug #29 

## Merge to Development - Checklist before requesting a review
- [x] I have performed a self-review of my code.  It runs with `mvn clean verify`
- [ ] I have added thorough tests.

## Merge to Main - Checklist before requesting a review
- [ ] I have installed this version locally with `bin/deploy-head`
- [ ] I have tested on Debian with `docker build --no-cache -t "debian-bashpile" src/test/resources/docker/debian`
- [ ] I have regenerated the docutils documentation with `bin/generate-docs`