### PR TITLE
Feature/bast - Removed preambles

### DIFF
--- a/.github/workflows/build.ubuntu.yml
+++ b/.github/workflows/build.ubuntu.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
 
-    runs-on: michaelamiethystbashpile/bashpile:24.10
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/Formula/bashpile.rb
+++ b/Formula/bashpile.rb
@@ -2,8 +2,8 @@ class Bashpile < Formula
   desc "The Bash Transpiler: Write in a modern language and run in a Bash5 shell!"
   homepage "https://github.com/michael-amiethyst/homebrew-bashpile"
   license "MIT"
-  url "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "main", tag: "0.24.0"
-  head "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "development"
+  url "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "main", tag: "0.25.0"
+  head "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "feature/bast"
 
   # foundational dependencies
   depends_on "openjdk"

--- a/Formula/bashpile.rb
+++ b/Formula/bashpile.rb
@@ -26,7 +26,7 @@ class Bashpile < Formula
     FileUtils.cp "#{bin}/bpc", "#{bin}/bashpilec"
     bin.install "target/bpr"
     FileUtils.cp "#{bin}/bpr", "#{bin}/bashpile"
-    bin.install "target/stdlib"
+    bin.install "target/bashpile-stdlib"
   end
 
   test do

--- a/Formula/bashpile.rb
+++ b/Formula/bashpile.rb
@@ -3,7 +3,7 @@ class Bashpile < Formula
   homepage "https://github.com/michael-amiethyst/homebrew-bashpile"
   license "MIT"
   url "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "main", tag: "0.25.0"
-  head "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "feature/bast"
+  head "https://github.com/michael-amiethyst/homebrew-bashpile", using: :git, branch: "development"
 
   # foundational dependencies
   depends_on "openjdk"

--- a/bin/bpr.bps
+++ b/bin/bpr.bps
@@ -5,7 +5,7 @@
  * Manually deploy with `target/bpc --outputFile=target/bpr bin/bpr.bps`
  */
 
-source ${BASHPILE_HOME:=.}/target/bashpile-stdlib || source /usr/local/bin/bashpile-stdlib || source /opt/homebrew/bin/bashpile-stdlib
+import "bashpile-stdlib"
 assertGnuGetopt()
 
 // getopt

--- a/bin/bpr.bps
+++ b/bin/bpr.bps
@@ -5,7 +5,7 @@
  * Manually deploy with `target/bpc --outputFile=target/bpr bin/bpr.bps`
  */
 
-source ${BASHPILE_HOME:=.}/target/stdlib || source /usr/local/bin/stdlib || source /opt/homebrew/bin/stdlib
+source ${BASHPILE_HOME:=.}/target/bashpile-stdlib || source /usr/local/bin/bashpile-stdlib || source /opt/homebrew/bin/bashpile-stdlib
 assertGnuGetopt()
 
 // getopt

--- a/bin/create-bpc
+++ b/bin/create-bpc
@@ -3,3 +3,4 @@
 echo '#!/usr/bin/java -jar' > target/bpc
 /bin/cat target/bashpile.jar >> target/bpc
 /bin/chmod +x target/bpc
+printf "Created bpc in directory %s" "$PWD"

--- a/bin/generate-docs
+++ b/bin/generate-docs
@@ -2,8 +2,10 @@
 
 // ensure docutils is installed
 
-mkdir docs/generated 2>/dev/null || true
-mkdir docs/generated/tutorial 2>/dev/null || true
-docutils docs/enduser/index.rst docs/generated/index.html
-docutils docs/enduser/tutorial/index.rst docs/generated/tutorial/index.html
-print("Docs generated at BASHPILE_HOME/docs/generated")
+dir: str = "target/generated-docs"
+mkdir "$dir" 2>/dev/null || true
+mkdir "$dir/tutorial" 2>/dev/null || true
+docutils "docs/enduser/index.rst" "$dir/index.html"
+docutils "docs/enduser/tutorial/index.rst" "$dir/tutorial/index.html"
+currentDir: str = #(printf "%s" "$PWD")
+print("Docs generated at " + currentDir + "/" + dir)

--- a/bin/testrig
+++ b/bin/testrig
@@ -4,7 +4,7 @@
  * Usage: bin/testrig src/test/resources/currTest
 */
 
-source ${BASHPILE_HOME:=.}/target/bashpile-stdlib || source /usr/local/bin/bashpile-stdlib || source /opt/homebrew/bin/bashpile-stdlib
+import "bashpile-stdlib"
 
 CLASS_PATH_FILE: readonly str = createTempFile("cpath.txt")
 mvn dependency:build-classpath -Dmdep.outputFile="$CLASS_PATH_FILE"

--- a/bin/testrig
+++ b/bin/testrig
@@ -4,7 +4,7 @@
  * Usage: bin/testrig src/test/resources/currTest
 */
 
-source ${BASHPILE_HOME:=.}/target/stdlib || source /usr/local/bin/stdlib || source /opt/homebrew/bin/stdlib
+source ${BASHPILE_HOME:=.}/target/bashpile-stdlib || source /usr/local/bin/bashpile-stdlib || source /opt/homebrew/bin/bashpile-stdlib
 
 CLASS_PATH_FILE: readonly str = createTempFile("cpath.txt")
 mvn dependency:build-classpath -Dmdep.outputFile="$CLASS_PATH_FILE"

--- a/bin/testrigTokens
+++ b/bin/testrigTokens
@@ -4,7 +4,7 @@
  * Usage: bin/testrigTokens src/test/resources/currTest
 */
 
-source ${BASHPILE_HOME:=.}/target/stdlib  || source /usr/local/bin/stdlib || source /opt/homebrew/bin/stdlib
+source ${BASHPILE_HOME:=.}/target/bashpile-stdlib  || source /usr/local/bin/bashpile-stdlib || source /opt/homebrew/bin/bashpile-stdlib
 
 CLASS_PATH_FILE: readonly str = createTempFile("cpath.txt")
 mvn dependency:build-classpath -Dmdep.outputFile="$CLASS_PATH_FILE"

--- a/bin/testrigTokens
+++ b/bin/testrigTokens
@@ -4,7 +4,7 @@
  * Usage: bin/testrigTokens src/test/resources/currTest
 */
 
-source ${BASHPILE_HOME:=.}/target/bashpile-stdlib  || source /usr/local/bin/bashpile-stdlib || source /opt/homebrew/bin/bashpile-stdlib
+import "bashpile-stdlib"
 
 CLASS_PATH_FILE: readonly str = createTempFile("cpath.txt")
 mvn dependency:build-classpath -Dmdep.outputFile="$CLASS_PATH_FILE"

--- a/docs/contributor/changelog.md
+++ b/docs/contributor/changelog.md
@@ -36,3 +36,4 @@
 * 0.23.1 - Bugfixes (#47 and #48) and refactoring
 * 0.23.2 - Start of optional arguments (only 1), TODO fixes
 * 0.24.0 - Optional arguments and default arguments more generally
+* 0.25.0 - Start of transition to having a Bashpile Abstract Syntax Tree instead of string munging 

--- a/docs/contributor/changelog.md
+++ b/docs/contributor/changelog.md
@@ -36,4 +36,4 @@
 * 0.23.1 - Bugfixes (#47 and #48) and refactoring
 * 0.23.2 - Start of optional arguments (only 1), TODO fixes
 * 0.24.0 - Optional arguments and default arguments more generally
-* 0.25.0 - Start of transition to having a Bashpile Abstract Syntax Tree instead of string munging 
+* 0.25.0 - Start of transition to having a Bashpile Abstract Syntax Tree instead of string munging, import statements

--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -2,22 +2,21 @@
 1. Create lib functions to disable/enable strict mode
    1. Rename stdlib to bashpile-stdlib
    2. Install to /etc/bashpile folder
-2. Move generated docs to /target, find a place to host
-3. Imports
+2. Imports
    1. Especially function return values into the type system
-4. More loops
+3. More loops
    1. do while loop
    2. C style for loop
    3. foreach loop
-5. Logging / debug so that we can debug functions that return strings
-6. Syntax highlighting in Intellij
-7. Hashes
-8. Refs
-9. String interpolation with $[]
+4. Logging / debug so that we can debug functions that return strings
+5. Syntax highlighting in Intellij
+6. Hashes
+7. Refs
+8. String interpolation with $[]
    1. have bpr use arguments, arguments[all] (args/argv alias?)
-10. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
-    1. finally blocks
-11. Enforce 'readonly' 
+9. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
+   1. finally blocks
+10. Enforce 'readonly' 
     1. Currently on the honor system, has to be implemented by Bashpile, not by `declare` due to workaround
 
 # Fixes and improvements

--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -1,22 +1,24 @@
 # 1.0 Roadmap
-1. Create lib functions to disable/enable strict mode
-   1. Rename stdlib to bashpile-stdlib
-   2. Install to /etc/bashpile folder
-2. Imports
+1. Remove preambles concept
+2. Convert Translation to a tree structure instead of a string concat model
+3. Change Translation payload from String (body) to bastData (that renders to string)
+4. Create lib functions to disable/enable strict mode
+   1. Install to /etc/bashpile folder
+5. Imports
    1. Especially function return values into the type system
-3. More loops
+6. More loops
    1. do while loop
    2. C style for loop
    3. foreach loop
-4. Logging / debug so that we can debug functions that return strings
-5. Syntax highlighting in Intellij
-6. Hashes
-7. Refs
-8. String interpolation with $[]
-   1. have bpr use arguments, arguments[all] (args/argv alias?)
-9. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
-   1. finally blocks
-10. Enforce 'readonly' 
+7. Logging / debug so that we can debug functions that return strings
+8. Syntax highlighting in Intellij
+9. Hashes
+10. Refs
+11. String interpolation with $[]
+    1. have bpr use arguments, arguments[all] (args/argv alias?)
+12. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
+    1. finally blocks
+13. Enforce 'readonly' 
     1. Currently on the honor system, has to be implemented by Bashpile, not by `declare` due to workaround
 
 # Fixes and improvements

--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -1,23 +1,22 @@
 # 1.0 Roadmap
-1. Remove preambles concept
-2. Convert Translation to a tree structure instead of a string concat model
-3. Change Translation payload from String (body) to bastData (that renders to string)
-4. Create lib functions to disable/enable strict mode
+1. Convert Translation to a tree structure instead of a string concat model
+2. Change Translation payload from String (body) to bastData (that renders to string)
+3. Create lib functions to disable/enable strict mode
    1. Install to /etc/bashpile folder
-5. Integrate imports into the type system
-6. More loops
+4. Integrate imports into the type system
+5. More loops
    1. do while loop
    2. C style for loop
    3. foreach loop
-7. Logging / debug so that we can debug functions that return strings
-8. Syntax highlighting in Intellij
-9. Hashes
-10. Refs
-11. String interpolation with $[]
+6. Logging / debug so that we can debug functions that return strings
+7. Syntax highlighting in Intellij
+8. Hashes
+9. Refs
+10. String interpolation with $[]
     1. have bpr use arguments, arguments[all] (args/argv alias?)
-12. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
+11. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
     1. finally blocks
-13. Enforce 'readonly' 
+12. Enforce 'readonly' 
     1. Currently on the honor system, has to be implemented by Bashpile, not by `declare` due to workaround
 
 # Fixes and improvements

--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -4,8 +4,7 @@
 3. Change Translation payload from String (body) to bastData (that renders to string)
 4. Create lib functions to disable/enable strict mode
    1. Install to /etc/bashpile folder
-5. Imports
-   1. Especially function return values into the type system
+5. Integrate imports into the type system
 6. More loops
    1. do while loop
    2. C style for loop

--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -3,23 +3,21 @@
    1. Rename stdlib to bashpile-stdlib
    2. Install to /etc/bashpile folder
 2. Move generated docs to /target, find a place to host
-3. Change architecture to create Bashpile AST (bast) and render to String after full context / metadata known
-   1. e.g. stop parsing and re-parsing strings with regex
-4. Imports
+3. Imports
    1. Especially function return values into the type system
-5. More loops
+4. More loops
    1. do while loop
    2. C style for loop
    3. foreach loop
-6. Logging / debug so that we can debug functions that return strings
-7. Syntax highlighting in Intellij
-8. Hashes
-9. Refs
-10. String interpolation with $[]
-    1. have bpr use arguments, arguments[all] (args/argv alias?)
-11. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
+5. Logging / debug so that we can debug functions that return strings
+6. Syntax highlighting in Intellij
+7. Hashes
+8. Refs
+9. String interpolation with $[]
+   1. have bpr use arguments, arguments[all] (args/argv alias?)
+10. Exceptions and raise/throw statements (see ConditionalsBashpileTest.ifWithInlineCanRaiseError)
     1. finally blocks
-12. Enforce 'readonly' 
+11. Enforce 'readonly' 
     1. Currently on the honor system, has to be implemented by Bashpile, not by `declare` due to workaround
 
 # Fixes and improvements

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bashpile</groupId>
     <artifactId>bashpile</artifactId>
-    <version>0.24.0</version>
+    <version>0.25.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -260,14 +260,14 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>Generate stdlib</id>
+                        <id>Generate bashpile-stdlib</id>
                         <phase>package</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>
                         <configuration>
                             <executable>/bin/bash</executable>
-                            <commandlineArgs>-c "target/bpc --outputFile target/stdlib bin/stdlib.bps"</commandlineArgs>
+                            <commandlineArgs>-c "target/bpc --outputFile target/bashpile-stdlib bin/stdlib.bps"</commandlineArgs>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/main/antlr4/com/bashpile/BashpileLexer.g4
+++ b/src/main/antlr4/com/bashpile/BashpileLexer.g4
@@ -53,6 +53,7 @@ Exported : 'exported';
 Readonly : 'readonly';
 ListOf   : 'listOf';
 While    : 'while';
+Import   : 'import';
 
 // operators, in precidence order
 // opening parenthesis

--- a/src/main/antlr4/com/bashpile/BashpileParser.g4
+++ b/src/main/antlr4/com/bashpile/BashpileParser.g4
@@ -5,7 +5,8 @@ program: statement+;
 
 // statements, in descending order of complexity
 statement
-    : ShellLine Newline                         # shellLineStatement
+    : Import StringValues                       # importStatement
+    | ShellLine Newline                         # shellLineStatement
     | While expression Colon indentedStatements # whileStatement
     | Function Id paramaters (Arrow complexType)?      # functionForwardDeclarationStatement
     | Function Id paramaters tags? (Arrow complexType)?

--- a/src/main/java/com/bashpile/engine/BashTranslationEngine.java
+++ b/src/main/java/com/bashpile/engine/BashTranslationEngine.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 import static com.bashpile.Asserts.assertTypesCoerce;
 import static com.bashpile.engine.BashTranslationHelper.*;
@@ -91,9 +92,11 @@ public class BashTranslationEngine implements TranslationEngine {
         expressionSetups.add(setup);
     }
 
+    @NotNull
+    @Override
     public Translation getExpressionSetup() {
         try {
-            return expressionSetups.stream().reduce(Translation::add).orElseThrow();
+            return expressionSetups.stream().reduce(Translation::add).orElse(EMPTY_TRANSLATION);
         } finally {
             // the list is drained, reset
             expressionSetups = new ArrayList<>();
@@ -360,7 +363,8 @@ public class BashTranslationEngine implements TranslationEngine {
 
         // order is comment, preamble, subcomment, variable declaration, assignment
         final Translation subcommentToAssignment = subcomment.add(variableDeclaration).add(assignment);
-        return comment.add(subcommentToAssignment.mergePreamble()).type(NA_TYPE).metadata(NORMAL);
+        subcommentToAssignment.preamble(); // drain preamble, use expressionSetup instead
+        return comment.add(getExpressionSetup()).add(subcommentToAssignment).type(NA_TYPE).metadata(NORMAL);
     }
 
     @Override

--- a/src/main/java/com/bashpile/engine/BashTranslationEngine.java
+++ b/src/main/java/com/bashpile/engine/BashTranslationEngine.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import static com.bashpile.Asserts.assertTypesCoerce;
 import static com.bashpile.engine.BashTranslationHelper.*;
@@ -58,8 +57,8 @@ public class BashTranslationEngine implements TranslationEngine {
     private final Set<String> foundForwardDeclarations = new HashSet<>();
 
     /**
-     * When an expression needs a statement inserted before the expression
-     * Were called preambles
+     * When an expression needs a statement inserted before the expression.
+     * <p>Replaces preambles.</p>
      */
     private List<Translation> expressionSetups = new ArrayList<>();
 
@@ -92,7 +91,7 @@ public class BashTranslationEngine implements TranslationEngine {
         expressionSetups.add(setup);
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public Translation getExpressionSetup() {
         try {

--- a/src/main/java/com/bashpile/engine/BashTranslationEngine.java
+++ b/src/main/java/com/bashpile/engine/BashTranslationEngine.java
@@ -543,7 +543,6 @@ public class BashTranslationEngine implements TranslationEngine {
                     // only add quotes if needed
                     .map(tr -> !(tr.body().startsWith("\"") && tr.body().endsWith("\"")) ? tr.quoteBody() : tr)
                     .reduce((left, right) -> new Translation(
-                            left.preamble() + right.preamble(),
                             left.body() + " " + right.body(),
                             right.type(),
                             right.metadata()))
@@ -553,8 +552,7 @@ public class BashTranslationEngine implements TranslationEngine {
         // lookup return type of this function
         final Type retType = expectedTypes.returnType();
 
-        Translation ret = new Translation(
-                argumentTranslations.preamble(), functionName + argumentTranslations.body(), retType, List.of(NORMAL));
+        Translation ret = new Translation(functionName + argumentTranslations.body(), retType, List.of(NORMAL));
         // suppress output if we are printing to output as part of a work-around to return a string
         // this covers the case of calling a function without using the return
         if (retType.isStr()) {

--- a/src/main/java/com/bashpile/engine/BashTranslationEngine.java
+++ b/src/main/java/com/bashpile/engine/BashTranslationEngine.java
@@ -357,8 +357,8 @@ public class BashTranslationEngine implements TranslationEngine {
         final Translation assignment = toStringTranslation(assignmentBody);
 
         // order is comment, variable declaration, assignment
-        final Translation subcommentToAssignment = variableDeclaration.add(assignment);
-        return comment.add(getExpressionSetup()).add(subcommentToAssignment).type(NA_TYPE).metadata(NORMAL);
+        return comment.add(getExpressionSetup()).add(variableDeclaration).add(assignment)
+                .type(NA_TYPE).metadata(NORMAL);
     }
 
     @Override
@@ -408,7 +408,6 @@ public class BashTranslationEngine implements TranslationEngine {
                 .formatted(lhsVariableName, listAccessor, assignOperator, rhsExprTranslation.body());
         final Translation reassignment = toStringTranslation(reassignmentBody);
 
-        // order is: comment, reassignment
         return comment.add(reassignment).assertParagraphBody().type(NA_TYPE).metadata(NORMAL);
     }
 
@@ -424,7 +423,6 @@ public class BashTranslationEngine implements TranslationEngine {
         // change $(( )) to _=$(( )) to avoid executing a number.  Fixes ShellCheck error SC2084
         expr = expr.lambdaBody(body -> !body.startsWith("$((") ? body : "_=" + body).add(NEWLINE);
         final Translation comment = createCommentTranslation("expression statement", lineNumber(ctx));
-        // order is: comment, expr
         return comment.add(expr).type(expr.type()).metadata(expr.metadata());
     }
 

--- a/src/main/java/com/bashpile/engine/BashTranslationHelper.java
+++ b/src/main/java/com/bashpile/engine/BashTranslationHelper.java
@@ -72,14 +72,6 @@ public class BashTranslationHelper {
         return toStringTranslation("# %s, Bashpile line %d\n".formatted(name, lineNumber));
     }
 
-    /* package */ static @Nonnull Translation subcommentTranslationOrDefault(
-            final boolean subcommentNeeded, @Nonnull final String name) {
-        if (subcommentNeeded) {
-            return toStringTranslation("## %s\n".formatted(name));
-        }
-        return UNKNOWN_TRANSLATION;
-    }
-
     /**
      * Get left hand side's type.
      *
@@ -189,10 +181,7 @@ public class BashTranslationHelper {
                 %s
                     ;;
                 """.formatted(pattern.body(), statements.body());
-        return toStringTranslation(template)
-                .lambdaBodyLines(x -> "    " + x)
-                .addPreamble(pattern.preamble())
-                .addPreamble(statements.preamble());
+        return toStringTranslation(template).lambdaBodyLines(x -> "    " + x);
     }
 
     // helpers to helpers

--- a/src/main/java/com/bashpile/engine/BashpileVisitor.java
+++ b/src/main/java/com/bashpile/engine/BashpileVisitor.java
@@ -81,7 +81,11 @@ public class BashpileVisitor extends BashpileParserBaseVisitor<Translation> {
         contextRoot = ctx;
 
         final Translation statementsTranslations = ctx.statement().stream()
-                .map(this::visit)
+                .map(antlrParseTree -> {
+                    // this replaces the "preambles" concept
+                    final Translation r = this.visit(antlrParseTree);
+                    return translator.getExpressionSetup().add(r);
+                })
                 .map(Translation::assertEmptyPreamble)
                 .reduce(Translation::add)
                 .orElseThrow();

--- a/src/main/java/com/bashpile/engine/BashpileVisitor.java
+++ b/src/main/java/com/bashpile/engine/BashpileVisitor.java
@@ -21,7 +21,8 @@ import static com.bashpile.engine.Translation.NEWLINE;
 import static com.bashpile.engine.strongtypes.TranslationMetadata.NORMAL;
 
 /**
- * Antlr4 calls these methods.
+ * Antlr4 calls these methods.  Delegates to the {@code TranslationEngine}.
+ * @see TranslationEngine
  */
 public class BashpileVisitor extends BashpileParserBaseVisitor<Translation> {
 
@@ -79,7 +80,7 @@ public class BashpileVisitor extends BashpileParserBaseVisitor<Translation> {
         // save root for later usage
         contextRoot = ctx;
 
-        final Translation statementTranslation = ctx.statement().stream()
+        final Translation statementsTranslations = ctx.statement().stream()
                 .map(this::visit)
                 .map(Translation::assertEmptyPreamble)
                 .reduce(Translation::add)
@@ -88,11 +89,15 @@ public class BashpileVisitor extends BashpileParserBaseVisitor<Translation> {
         // add header, libs and statements
         return translator.originHeader()
                 .add(translator.strictModeHeader())
-                .add(translator.importsHeaders())
-                .add(statementTranslation);
+                .add(statementsTranslations);
     }
 
     // visit statements
+
+    @Override
+    public Translation visitImportStatement(BashpileParser.ImportStatementContext ctx) {
+        return translator.importStatement(ctx);
+    }
 
     @Override
     public Translation visitWhileStatement(BashpileParser.WhileStatementContext ctx) {

--- a/src/main/java/com/bashpile/engine/BashpileVisitor.java
+++ b/src/main/java/com/bashpile/engine/BashpileVisitor.java
@@ -86,7 +86,6 @@ public class BashpileVisitor extends BashpileParserBaseVisitor<Translation> {
                     final Translation r = this.visit(antlrParseTree);
                     return translator.getExpressionSetup().add(r);
                 })
-                .map(Translation::assertEmptyPreamble)
                 .reduce(Translation::add)
                 .orElseThrow();
 

--- a/src/main/java/com/bashpile/engine/ListOfTranslation.java
+++ b/src/main/java/com/bashpile/engine/ListOfTranslation.java
@@ -61,29 +61,6 @@ public class ListOfTranslation extends Translation {
 
     @Nonnull
     @Override
-    public Translation addPreamble(@Nonnull String additionalPreamble) {
-        throw new UnsupportedOperationException("Not supported for ListTranslations");
-    }
-
-    @Nonnull
-    @Override
-    public Translation assertEmptyPreamble() {
-        throw new UnsupportedOperationException("Not supported for ListTranslations");
-    }
-
-    @Override
-    public boolean hasPreamble() {
-        return translations.stream().map(Translation::hasPreamble).reduce(true, (a, b) -> a && b);
-    }
-
-    @Nonnull
-    @Override
-    public Translation mergePreamble() {
-        throw new UnsupportedOperationException("Not supported for ListTranslations");
-    }
-
-    @Nonnull
-    @Override
     public Translation body(@Nonnull String nextBody) {
         throw new UnsupportedOperationException("Not supported for ListTranslations");
     }

--- a/src/main/java/com/bashpile/engine/ListOfTranslation.java
+++ b/src/main/java/com/bashpile/engine/ListOfTranslation.java
@@ -169,11 +169,6 @@ public class ListOfTranslation extends Translation {
     }
 
     @Override
-    public @Nonnull String preamble() {
-        return translations.stream().map(Translation::preamble).collect(Collectors.joining("\n")).trim();
-    }
-
-    @Override
     public  @Nonnull Type type() {
         return super.type();
     }

--- a/src/main/java/com/bashpile/engine/Translation.java
+++ b/src/main/java/com/bashpile/engine/Translation.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang3.StringUtils;
 import static com.bashpile.Asserts.assertIsParagraph;
 import static com.bashpile.Strings.lambdaAllLines;
 import static com.bashpile.engine.strongtypes.Type.*;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * A target shell (e.g. Bash) translation of some Bashpile script.  Immutable.
@@ -47,8 +46,6 @@ public class Translation {
     private static final Pattern INT_PATTERN = Pattern.compile("\\d+");
 
     private static final Pattern FLOAT_PATTERN = Pattern.compile("\\d+(?:\\.\\d+)?");
-
-    @Nonnull private String preamble;
 
     @Nonnull private final String body;
 
@@ -97,27 +94,6 @@ public class Translation {
 
     // constructors
 
-    /**
-     * @param preamble This is text that needs to be emitted before the rest of the translation.<br>
-     *                 This is to handle the case of a nested command substitution, since they are not supported well
-     *                 in Bash (errored exit codes are ignored) we need to assign the inner command substitution to a
-     *                 variable and have the <code>body</code> just be the variable.
-     * @param body     The target shell script (e.g. Bash) literal text.
-     * @param type     The Bashpile type.  For Shell Strings and Command Substitutions this is the type of the result.
-     *                 E.g. $(expr 1 + 1) could have a type of int.
-     * @param metadata Further information on the type (e.g. is this a subshell?)
-     */
-    public Translation(
-            @Nonnull String preamble,
-            @Nonnull String body,
-            @Nonnull Type type,
-            @Nonnull List<TranslationMetadata> metadata) {
-        this.preamble = preamble;
-        this.body = body;
-        this.type = type;
-        this.metadata = metadata;
-    }
-
     public Translation(@Nonnull final String text) {
         this(text, UNKNOWN_TYPE, List.of());
     }
@@ -126,14 +102,22 @@ public class Translation {
             @Nonnull final String text,
             @Nonnull final Type type,
             @Nonnull final TranslationMetadata translationMetadata) {
-        this("", text, type, List.of(translationMetadata));
+        this(text, type, List.of(translationMetadata));
     }
 
+    /**
+     * @param body     The target shell script (e.g. Bash) literal text.
+     * @param type     The Bashpile type.  For Shell Strings and Command Substitutions this is the type of the result.
+     *                 E.g. $(expr 1 + 1) could have a type of int.
+     * @param metadata Further information on the type (e.g. is this a subshell?)
+     */
     public Translation(
-            @Nonnull final String text,
+            @Nonnull final String body,
             @Nonnull final Type type,
-            @Nonnull final List<TranslationMetadata> translationMetadata) {
-        this("", text, type, translationMetadata);
+            @Nonnull final List<TranslationMetadata> metadata) {
+        this.body = body;
+        this.type = type;
+        this.metadata = metadata;
     }
 
     /**
@@ -156,7 +140,7 @@ public class Translation {
         nextType = nextType.isUnknown() ? other.type : nextType;
         // favor INT or FLOAT over NUMBER
         nextType = nextType.isNumber() && other.type.isNumeric() ? other.type : nextType;
-        return new Translation(preamble + other.preamble, body + other.body, nextType, nextMetadata);
+        return new Translation(body + other.body, nextType, nextMetadata);
     }
 
     // preamble instance methods
@@ -165,7 +149,7 @@ public class Translation {
      * Appends additionalPreamble to this object's preamble
      */
     public @Nonnull Translation addPreamble(@Nonnull final String additionalPreamble) {
-        return new Translation(preamble + additionalPreamble, body, type, metadata);
+        return new Translation(body, type, metadata);
     }
 
     /**
@@ -182,14 +166,14 @@ public class Translation {
      * Checks if this translation has a preamble
      */
     public boolean hasPreamble() {
-        return !isEmpty(preamble);
+        return false;
     }
 
     /**
      * Prepends the preamble to the body
      */
     public @Nonnull Translation mergePreamble() {
-        return new Translation(preamble + body, type, metadata);
+        return new Translation(body, type, metadata);
     }
 
     // body instance methods
@@ -198,7 +182,7 @@ public class Translation {
      * Replaces the body
      */
     public @Nonnull Translation body(@Nonnull final String nextBody) {
-        return new Translation(preamble, nextBody, type, metadata);
+        return new Translation(nextBody, type, metadata);
     }
 
     /**
@@ -274,7 +258,7 @@ public class Translation {
      * Apply arbitrary function to body.  E.g. `str -> str`.
      */
     public @Nonnull Translation lambdaBody(@Nonnull final Function<String, String> lambda) {
-        return new Translation(preamble, lambda.apply(body), type, metadata);
+        return new Translation(lambda.apply(body), type, metadata);
     }
 
     /**
@@ -298,7 +282,7 @@ public class Translation {
      * Replaces the type.
      */
     public @Nonnull Translation type(@Nonnull final Type typecastType) {
-        return new Translation(preamble, body, typecastType, metadata);
+        return new Translation(body, typecastType, metadata);
     }
 
     /** Is the type basic (e.g. not a List, Hash or Ref)? */
@@ -350,14 +334,14 @@ public class Translation {
      * Replaces the type metadata
      */
     public @Nonnull Translation metadata(@Nonnull final TranslationMetadata meta) {
-        return new Translation(preamble, body, type, List.of(meta));
+        return new Translation(body, type, List.of(meta));
     }
 
     /**
      * Replaces the type metadata
      */
     public @Nonnull Translation metadata(@Nonnull final List<TranslationMetadata> meta) {
-        return new Translation(preamble, body, type, meta);
+        return new Translation(body, type, meta);
     }
 
     /**
@@ -375,7 +359,7 @@ public class Translation {
             nextMetadata.addAll(metadata);
             nextMetadata.remove(TranslationMetadata.NEEDS_INLINING_OFTEN);
             // in Bash $((subshell)) is an arithmetic operator in Bash but $( (subshell) ) isn't
-            return new Translation(preamble, "$( %s )".formatted(nextBody), type, nextMetadata);
+            return new Translation("$( %s )".formatted(nextBody), type, nextMetadata);
         } // else
         return this;
     }
@@ -404,11 +388,7 @@ public class Translation {
      * Drains the preamble; blanks out the preamble as a side effect to indicate that it has been handled and not lost.
      */
     public @Nonnull String preamble() {
-        try {
-            return preamble;
-        } finally {
-            preamble = "";
-        }
+        return "";
     }
 
     public @Nonnull String body() {
@@ -428,15 +408,14 @@ public class Translation {
         if (obj == this) return true;
         if (obj == null || obj.getClass() != this.getClass()) return false;
         var that = (Translation) obj;
-        return Objects.equals(this.preamble, that.preamble) &&
-                Objects.equals(this.body, that.body) &&
+        return Objects.equals(this.body, that.body) &&
                 Objects.equals(this.type, that.type) &&
                 Objects.equals(this.metadata, that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(preamble, body, type, metadata);
+        return Objects.hash(body, type, metadata);
     }
 
 }

--- a/src/main/java/com/bashpile/engine/Translation.java
+++ b/src/main/java/com/bashpile/engine/Translation.java
@@ -11,7 +11,6 @@ import javax.annotation.Nonnull;
 import com.bashpile.Strings;
 import com.bashpile.engine.strongtypes.TranslationMetadata;
 import com.bashpile.engine.strongtypes.Type;
-import com.bashpile.exceptions.BashpileUncheckedAssertionException;
 import com.google.common.collect.Streams;
 import org.apache.commons.lang3.StringUtils;
 
@@ -121,7 +120,7 @@ public class Translation {
     }
 
     /**
-     * Accumulates all the stream translations' preambles and bodies into the result
+     * Accumulates all the stream translations' bodies into the result
      */
     public static @Nonnull Translation toTranslation(@Nonnull final Stream<Translation> stream) {
         return stream.reduce(Translation::add).orElseThrow();
@@ -130,7 +129,7 @@ public class Translation {
     // instance methods
 
     /**
-     * Concatenates other's preamble and body to this preamble and body
+     * Concatenates other's body, type and metadata to this object's
      */
     public @Nonnull Translation add(@Nonnull final Translation other) {
         final List<TranslationMetadata> nextMetadata =
@@ -141,39 +140,6 @@ public class Translation {
         // favor INT or FLOAT over NUMBER
         nextType = nextType.isNumber() && other.type.isNumeric() ? other.type : nextType;
         return new Translation(body + other.body, nextType, nextMetadata);
-    }
-
-    // preamble instance methods
-
-    /**
-     * Appends additionalPreamble to this object's preamble
-     */
-    public @Nonnull Translation addPreamble(@Nonnull final String additionalPreamble) {
-        return new Translation(body, type, metadata);
-    }
-
-    /**
-     * Ensures this translation has no preamble
-     */
-    public @Nonnull Translation assertEmptyPreamble() {
-        if (hasPreamble()) {
-            throw new BashpileUncheckedAssertionException("Found preamble in translation: " + this.body);
-        }
-        return this;
-    }
-
-    /**
-     * Checks if this translation has a preamble
-     */
-    public boolean hasPreamble() {
-        return false;
-    }
-
-    /**
-     * Prepends the preamble to the body
-     */
-    public @Nonnull Translation mergePreamble() {
-        return new Translation(body, type, metadata);
     }
 
     // body instance methods
@@ -366,7 +332,7 @@ public class Translation {
 
     @Override
     public String toString() {
-        return assertEmptyPreamble().body;
+        return body;
     }
 
     // helpers
@@ -382,13 +348,6 @@ public class Translation {
         } else {
             return tr;
         }
-    }
-
-    /**
-     * Drains the preamble; blanks out the preamble as a side effect to indicate that it has been handled and not lost.
-     */
-    public @Nonnull String preamble() {
-        return "";
     }
 
     public @Nonnull String body() {

--- a/src/main/java/com/bashpile/engine/TranslationEngine.java
+++ b/src/main/java/com/bashpile/engine/TranslationEngine.java
@@ -1,5 +1,7 @@
 package com.bashpile.engine;
 
+import javax.annotation.Nonnull;
+
 import com.bashpile.BashpileParser;
 
 /**
@@ -16,6 +18,12 @@ public interface TranslationEngine {
      * So you make a TranslationEngine, pass to the BashpileVisitor then set the visitor.
      */
     void setVisitor(final BashpileVisitor visitor);
+
+    /**
+     * Some expressions need a statement executed beforehand, after the expression is translated this buffer is filled.
+     * Calling this also drains the buffer.
+     */
+    @Nonnull Translation getExpressionSetup();
 
     // headers
 

--- a/src/main/java/com/bashpile/engine/TranslationEngine.java
+++ b/src/main/java/com/bashpile/engine/TranslationEngine.java
@@ -4,6 +4,9 @@ import com.bashpile.BashpileParser;
 
 /**
  * Methods translate small parser rules (e.g. statements and expressions) to the target language.
+ * Exists to allow for other implementations in the future (e.g. sh, ksh, Bash3).
+ * Currently only has {@code BashTranslationEngine}.
+ * @see BashTranslationEngine
  */
 public interface TranslationEngine {
 
@@ -24,10 +27,9 @@ public interface TranslationEngine {
      */
     Translation strictModeHeader();
 
-    /** To source our bundled libraries */
-    Translation importsHeaders();
-
     // statement translations
+
+    Translation importStatement(BashpileParser.ImportStatementContext ctx);
 
     /** Translates a while loop */
     Translation whileStatement(final BashpileParser.WhileStatementContext ctx);

--- a/src/main/java/com/bashpile/engine/TypecastUtils.java
+++ b/src/main/java/com/bashpile/engine/TypecastUtils.java
@@ -16,6 +16,8 @@ import static com.bashpile.engine.strongtypes.Type.INT_TYPE;
 public class TypecastUtils {
     // TODO consistent C style number casts, we can't check for correctness of non-literals (but we allow them)
 
+    public static BashTranslationEngine engine = null;
+
     /* package */ static @Nonnull Translation typecastFromBool(
             @Nonnull Translation expression,
             @Nonnull final Type castTo,
@@ -105,9 +107,11 @@ public class TypecastUtils {
             String varName = StringUtils.stripStart(expression.body(), "${");
             varName = StringUtils.stripEnd(varName, "}");
             if (!varName.matches("\\d")) {
-                return expression.addPreamble("""
-                                %s="$(printf '%%d' "%s" 2>/dev/null || true)"
-                                """.formatted(varName, expression))
+                String setupStatementText = """
+                        %s="$(printf '%%d' "%s" 2>/dev/null || true)"
+                        """.formatted(varName, expression);
+                engine.addExpressionSetup(new Translation(setupStatementText));
+                return expression.addPreamble(setupStatementText)
                         .type(INT_TYPE);
             } else {
                 // trying to reassign $1, $2, etc

--- a/src/main/java/com/bashpile/engine/TypecastUtils.java
+++ b/src/main/java/com/bashpile/engine/TypecastUtils.java
@@ -108,8 +108,8 @@ public class TypecastUtils {
             String varName = StringUtils.stripStart(expression.body(), "${");
             varName = StringUtils.stripEnd(varName, "}");
             if (!varName.matches("\\d")) {
-                String setupStatementText = "";
-                // only convert normal variables with printf (not calculations, etc)
+                String setupStatementText;
+                // only convert normal variables with printf (not calculations, etc.)
                 if (expression.metadata().isEmpty()
                         || (expression.metadata().size() == 1 && expression.metadata().contains(NORMAL))) {
                     setupStatementText = """
@@ -117,10 +117,10 @@ public class TypecastUtils {
                             """.formatted(varName, expression);
                     engine.addExpressionSetup(new Translation(setupStatementText));
                 }
-                return expression.addPreamble(setupStatementText).type(INT_TYPE);
+                return expression.type(INT_TYPE);
             } else {
-                // trying to reassign $1, $2, etc
-                // too complex to set an individual varable with the command 'set', throw
+                // trying to reassign $1, $2, etc.
+                // too complex to set an individual variable with the command 'set', throw
                 final String message = "Could not cast $1, $2, etc.  Assign to a local variable and typecast that.";
                 throw new TypeError(message, lineNumber);
             }

--- a/src/main/java/com/bashpile/engine/strongtypes/TranslationMetadata.java
+++ b/src/main/java/com/bashpile/engine/strongtypes/TranslationMetadata.java
@@ -2,8 +2,6 @@ package com.bashpile.engine.strongtypes;
 
 import com.bashpile.engine.Translation;
 
-import java.util.function.Function;
-
 /**
  * Additional information about a Translation's Type.
  * So we can have a Command that evaluates to an int for example.
@@ -13,7 +11,7 @@ public enum TranslationMetadata {
     NORMAL,
     /**
      * Calc expressions (`bc`) frequently need to be inlines, but not always.
-     * @see Translation#inlineAsNeeded(Function)
+     * @see Translation#inlineAsNeeded()
      */
     NEEDS_INLINING_OFTEN,
     CALCULATION,

--- a/src/main/kotlin/com/bashpile/engine/BashTranslationEngineDelegate.kt
+++ b/src/main/kotlin/com/bashpile/engine/BashTranslationEngineDelegate.kt
@@ -127,7 +127,6 @@ class BashTranslationEngineDelegate(private val visitor: BashpileVisitor) {
                     .lambdaBody { it.replace("exit 1", "return 1") }
                 }.reduce { obj: Translation, other: Translation? -> obj.add(other!!) }
                 .orElseThrow()
-                .assertEmptyPreamble()
 
             // put it all together in one big translation
             namedParams = Asserts.assertIsLine(namedParams).removeSuffix("\n")
@@ -183,9 +182,7 @@ class BashTranslationEngineDelegate(private val visitor: BashpileVisitor) {
             }
             .reduce { tr: Translation, otherTranslation: Translation? -> tr.add(otherTranslation!!) }
             .orElseThrow()
-        val subcomment = subcommentTranslationOrDefault(arguments.hasPreamble(), "print statement body")
-        return comment.add(subcomment.add(arguments).mergePreamble())
-
+        return comment.add(arguments)
     }
 
     fun returnPsudoStatement(ctx: BashpileParser.ReturnPsudoStatementContext, typeStack: TypeStack): Translation {
@@ -227,7 +224,7 @@ class BashTranslationEngineDelegate(private val visitor: BashpileVisitor) {
             }
         }
         exprTranslation = exprTranslation.body(Strings.lambdaLastLine(exprTranslation.body(), returnLineLambda))
-        return comment.add(exprTranslation.mergePreamble())
+        return comment.add(exprTranslation)
     }
 
     fun parenthesisExpression(ctx: BashpileParser.ParenthesisExpressionContext): Translation {
@@ -356,9 +353,6 @@ class BashTranslationEngineDelegate(private val visitor: BashpileVisitor) {
         }
 
         val body = "${translations[0].unquoteBody().body()} $operator ${translations[1].unquoteBody().body()}"
-        return toStringTranslation(body)
-            .addPreamble(translations[0].preamble())
-            .addPreamble(translations[1].preamble())
-            .metadata(CONDITIONAL)
+        return toStringTranslation(body).metadata(CONDITIONAL)
     }
 }

--- a/src/main/kotlin/com/bashpile/engine/BashTranslationEngineDelegate.kt
+++ b/src/main/kotlin/com/bashpile/engine/BashTranslationEngineDelegate.kt
@@ -335,7 +335,7 @@ class BashTranslationEngineDelegate(private val visitor: BashpileVisitor) {
             // valueBeingTested will have [ ] if needed
             "$primary ${valueBeingTested.unquoteBody().body()}"
         }
-        return Translation(valueBeingTested.preamble(), body, Type.STR_TYPE, listOf(CONDITIONAL))
+        return Translation(body, Type.STR_TYPE, listOf(CONDITIONAL))
     }
 
     fun combiningExpression(ctx: BashpileParser.CombiningExpressionContext): Translation {

--- a/src/test/java/com/bashpile/maintests/BashpileTest.java
+++ b/src/test/java/com/bashpile/maintests/BashpileTest.java
@@ -38,7 +38,7 @@ abstract public class BashpileTest {
     }
 
     /** Runs {@code bashText} in a Bash environment */
-    protected @Nonnull ExecutionResults runText(@Nonnull final String bashText, @Nullable String... args) {
+    protected static @Nonnull ExecutionResults runText(@Nonnull final String bashText, @Nullable String... args) {
         LOG.debug("Start of:\n{}", bashText);
         try {
             return execute(BashpileMainHelper.transpileScript(bashText), args);
@@ -48,7 +48,7 @@ abstract public class BashpileTest {
     }
 
     /** Runs {@code file} from src/test/resources/scripts as a script in a Bash environment. */
-    protected @Nonnull ExecutionResults runPath(@Nonnull final Path file) {
+    protected static @Nonnull ExecutionResults runPath(@Nonnull final Path file) {
         final Path filename = !file.isAbsolute() ? Path.of("src/test/resources/scripts/" + file) : file;
         LOG.debug("Start of {}", filename);
         try {
@@ -60,7 +60,7 @@ abstract public class BashpileTest {
 
     // helpers
 
-    private @Nonnull ExecutionResults execute(@Nonnull final String bashScript, @Nullable final String[] args) {
+    private static @Nonnull ExecutionResults execute(@Nonnull final String bashScript, @Nullable final String[] args) {
         LOG.debug("In {}", System.getProperty("user.dir"));
         try {
             return BashShell.runAndJoin(bashScript, args);

--- a/src/test/java/com/bashpile/maintests/ConditionalsBashpileTest.java
+++ b/src/test/java/com/bashpile/maintests/ConditionalsBashpileTest.java
@@ -366,7 +366,6 @@ public class ConditionalsBashpileTest extends BashpileTest {
         assertEquals("true\n", results.stdout());
     }
 
-    // TODO remove "preamble" concept entirely
     @Test
     @Order(180)
     public void ifNotWhichWorks() {

--- a/src/test/java/com/bashpile/maintests/ShellStringBashpileTest.java
+++ b/src/test/java/com/bashpile/maintests/ShellStringBashpileTest.java
@@ -12,13 +12,13 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Order(50)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ShellStringBashpileTest extends BashpileTest {
 
-    final static String jarPath = "target/bashpile.jar";
+    /** May not exist if run with 'clean' step */
+    private final static String jarPath = "target/bashpile.jar";
 
     /**
      * Simple one word command
@@ -240,7 +240,6 @@ public class ShellStringBashpileTest extends BashpileTest {
     @Test()
     @Order(140)
     public void javaShellLineWorks() {
-        assumeTrue(Files.exists(Path.of(jarPath)));
         final ExecutionResults results = runText("""
                 jarPath: str = "%s"
                 java -help""".formatted(jarPath));
@@ -251,7 +250,6 @@ public class ShellStringBashpileTest extends BashpileTest {
     @Test()
     @Order(150)
     public void javaShellLineWithVariableWorks() {
-        assumeTrue(Files.exists(Path.of(jarPath)));
         final ExecutionResults results = runText("""
                 jarPath: str = "%s"
                 __bp_test=y java -help""".formatted(jarPath));
@@ -262,7 +260,6 @@ public class ShellStringBashpileTest extends BashpileTest {
     @Test()
     @Order(160)
     public void javaShellLineWithDoubleQuotedVariableWorks() {
-        assumeTrue(Files.exists(Path.of(jarPath)));
         final ExecutionResults results = runText("""
                 jarPath: str = "%s"
                 __bp_test="yes yes" java -help""".formatted(jarPath));
@@ -273,7 +270,6 @@ public class ShellStringBashpileTest extends BashpileTest {
     @Test()
     @Order(170)
     public void javaShellLineWithSingleQuotedVariableWorks() {
-        assumeTrue(Files.exists(Path.of(jarPath)));
         final ExecutionResults results = runText("""
                 jarPath: str = "%s"
                 __bp_test='yes yes' java -help""".formatted(jarPath));
@@ -284,7 +280,6 @@ public class ShellStringBashpileTest extends BashpileTest {
     @Test()
     @Order(180)
     public void shellLineInIfStatementWorks() {
-        assumeTrue(Files.exists(Path.of(jarPath)));
         final ExecutionResults results = runText("""
                 jarPath: str = "%s"
                 if "*.jarr" != jarPath:
@@ -297,7 +292,6 @@ public class ShellStringBashpileTest extends BashpileTest {
     @Test()
     @Order(190)
     public void nestedShellLineInIfStatementWorks() {
-        assumeTrue(Files.exists(Path.of(jarPath)));
         final ExecutionResults results = runText("""
                 jarPath: str = "%s"
                 if "*.jarr" == jarPath:

--- a/src/test/java/com/bashpile/maintests/StatementBashpileTest.java
+++ b/src/test/java/com/bashpile/maintests/StatementBashpileTest.java
@@ -14,6 +14,22 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class StatementBashpileTest extends BashpileTest {
 
+    /** Add a stub 'bashpile-stdlib' file for testing the import statement */
+    @BeforeAll
+    public static void setup() {
+        final ExecutionResults results = runText("touch ./target/bashpile-stdlib");
+        assertSuccessfulExitCode(results);
+    }
+
+    /** Remove the stub for a real implementation to be generated later */
+    @AfterAll
+    public static void cleanup() {
+        final ExecutionResults results = runText("rm ./target/bashpile-stdlib");
+        assertSuccessfulExitCode(results);
+    }
+
+    // tests
+
     @Test
     @Order(10)
     public void assignBoolWorks() {
@@ -462,5 +478,12 @@ class StatementBashpileTest extends BashpileTest {
                 """);
         assertSuccessfulExitCode(results);
         assertEquals("Other\n", results.stdout());
+    }
+
+    @Test
+    @Order(170)
+    public void importWorks() {
+        ExecutionResults results = runText("import 'bashpile-stdlib'");
+        assertSuccessfulExitCode(results);
     }
 }

--- a/src/test/java/com/bashpile/maintests/StatementBashpileTest.java
+++ b/src/test/java/com/bashpile/maintests/StatementBashpileTest.java
@@ -175,6 +175,7 @@ class StatementBashpileTest extends BashpileTest {
                 print(someVar)""");
         assertSuccessfulExitCode(results);
         assertEquals("0\n1\n", results.stdout());
+        assertEquals(results.stdout().indexOf("%d"), results.stdout().lastIndexOf("%d"), "Too many setups");
     }
 
     @Test


### PR DESCRIPTION
## Describe your changes
Removed the Translation preambles concept.  Uses expressionSetups instead.
Generated docs go into /target now
Partially implemented imports

## Merge to Development - Checklist before requesting a review
- [x] I have performed a self-review of my code.  
- [x] It runs with `mvn clean verify`
- [x] I have installed this version locally with `bin/deploy-head`
- [x] I have added thorough tests.

## Merge to Main - Checklist before requesting a review
- [ ] I have installed this version locally with `bin/deploy-head`
- [ ] I have tested on Debian with `docker build --no-cache -t "debian-bashpile" src/test/resources/docker/debian`
- [ ] I have regenerated the docutils documentation with `bin/generate-docs`